### PR TITLE
Feature/esbuild bundle minecraft scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
         "akhsync": "./dist/bin/akhsync.js"
     },
     "scripts": {
-        "build": "node esbuild.build.js",
+        "build": "tsc -p ./tsconfig.json --noEmit && esbuild src/**/*.ts --bundle --platform=node --outdir=dist --target=esnext --tsconfig=./tsconfig.json --format=esm --packages=external",
         "watch": "node esbuild.watch.js",
         "lint": "eslint --config ./eslint.config.js src/",
         "lint:fix": "eslint --fix --config ./eslint.config.js src/",
-        "release": "npm run lint:fix & npm run build -- --release"
+        "release": "npm run lint:fix & npm run build -- --minify"
     },
     "repository": {
         "type": "git",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -222,7 +222,7 @@ class BuildCommand {
             const entry = path.posix.join(path.basename(env.srcDir), directory, 'behavior_packs', 'scripts');
             const outdir = path.posix.join(path.basename(env.buildDir), directory, 'behavior_packs', 'scripts');
 
-            const tsconfigFiles = await glob(`./**/tsconfig.json`, {
+            const tsconfigFiles = await glob(`./tsconfig.json`, {
                 posix: true,
                 nodir: true,
                 ignore: [path.posix.join('node_modules', '**', 'tsconfig.json'), path.posix.join('**', 'behavior_packs', '**', 'tsconfig.json')],
@@ -255,19 +255,29 @@ class BuildCommand {
             //     packages: 'external',
             // });
 
+            // prettier-ignore
             await esbuild
                 .build({
                     entryPoints: [...scriptFiles],
-                    bundle: false,
+                    bundle: true,
                     outdir: outdir,
                     minify: Boolean(!this.dev),
                     sourcemap: Boolean(this.dev),
                     sourceRoot: path.join(env.srcDir, directory, 'behavior_packs', 'scripts'),
-                    platform: 'node',
-                    target: 'ESNext',
+                    platform: "node",
+                    target: "node18",
                     ...(tsconfigFlag ? { tsconfig: tsconfig } : {}),
                     format: 'esm',
-                    packages: 'external',
+                    external: [
+                        "@minecraft/server",
+                        "@minecraft/server-ui",
+                        "@minecraft/server-admin",
+                        "@minecraft/server-gametest",
+                        "@minecraft/server-net",
+                        "@minecraft/server-common",
+                        "@minecraft/server-editor",
+                        "@minecraft/debug-utilities",
+                    ]
                 })
                 .catch(() => {
                     error('Error building project');


### PR DESCRIPTION
scriptのbuildで直接tsc --noEmitとesbuildを使うように改善

- esbuildを使用したscriptのbundleを追加(https://jaylydev.github.io/posts/bundle-minecraft-scripts-esbuild/)
- tsconfigの取得glob pathを修正